### PR TITLE
Code Review: Fix Xcode 10.2 localization warnings (24128)

### DIFF
--- a/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
+++ b/OHHTTPStubs/OHHTTPStubs.xcodeproj/project.pbxproj
@@ -837,6 +837,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 09110A3819805F4800D175E4;
 			productRefGroup = 09110A4219805F4800D175E4 /* Products */;


### PR DESCRIPTION
> switch base localization on #24128

connects to https://github.com/BohemianCoding/Sketch/issues/24128
